### PR TITLE
OHTTP Relay fixes/improvements

### DIFF
--- a/ohttp-relay/Dockerfile
+++ b/ohttp-relay/Dockerfile
@@ -1,2 +1,14 @@
 FROM nginx:1.27-alpine
-COPY nginx.conf.template /etc/nginx/templates/default.conf.template
+
+# envsubst lives in gettext
+RUN apk add --no-cache gettext
+
+# Base nginx.conf that includes conf.d
+COPY nginx.conf /etc/nginx/nginx.conf
+
+# Our server config template (rendered at runtime)
+COPY default.conf.tpl /etc/nginx/conf.d/default.conf.tpl
+
+# Render template at container start (runs before nginx launches)
+COPY docker-entrypoint.d/10-render-nginx-conf.sh /docker-entrypoint.d/10-render-nginx-conf.sh
+RUN chmod +x /docker-entrypoint.d/10-render-nginx-conf.sh

--- a/ohttp-relay/default.conf.tpl
+++ b/ohttp-relay/default.conf.tpl
@@ -2,66 +2,66 @@
 resolver 127.0.0.11 ipv6=off valid=10s;
 
 upstream wallet_backend {
-    server wallet-backend-server:8002 resolve;
-    keepalive 16;
+		server wallet-backend-server:8002 resolve;
+		keepalive 16;
 		zone wallet_backend 64k; # runtime DNS resolution must be in shared mem
 }
 
 upstream ohttp_gateway {
-    server gateway:4567 resolve;
-    keepalive 16;
+		server gateway:4567 resolve;
+		keepalive 16;
 		zone ohttp_gateway 64k; # runtime DNS resolution must be in shared mem
 }
 
 server {
-    listen 80;
+		listen 80;
 
-    location = /health {
-        default_type application/json;
-        return 200 '{"ok":true,"service":"relay","impl":"nginx"}';
-    }
+		location = /health {
+				default_type application/json;
+				return 200 '{"ok":true,"service":"relay","impl":"nginx"}';
+		}
 
-    # Internal auth subrequest — checks Authorization against the backend
-    location = /_auth {
-        internal;
-        proxy_pass http://wallet_backend/helper/auth-check;
-        proxy_pass_request_body off;
-        proxy_set_header Content-Length "";
+		# Internal auth subrequest — checks Authorization against the backend
+		location = /_auth {
+				internal;
+				proxy_pass http://wallet_backend/helper/auth-check;
+				proxy_pass_request_body off;
+				proxy_set_header Content-Length "";
 
-        proxy_set_header Authorization $http_authorization;
-        proxy_set_header Cookie $http_cookie;
-        proxy_set_header X-Original-URI $request_uri;
-        proxy_set_header X-Real-IP        $remote_addr;
-        proxy_set_header X-Forwarded-For  $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
+				proxy_set_header Authorization $http_authorization;
+				proxy_set_header Cookie $http_cookie;
+				proxy_set_header X-Original-URI $request_uri;
+				proxy_set_header X-Real-IP        $remote_addr;
+				proxy_set_header X-Forwarded-For  $proxy_add_x_forwarded_for;
+				proxy_set_header X-Forwarded-Proto $scheme;
+		}
 
-    location ~ ^/api/relay/?$ {
-        # Preflight: answer directly
-        if ($request_method = OPTIONS) {
-            add_header 'Access-Control-Allow-Origin'  ${CORS_ALLOWED_ORIGINS} always;
-            add_header 'Access-Control-Allow-Methods' 'POST, OPTIONS' always;
-            add_header 'Access-Control-Allow-Headers' 'Content-Type, Accept, Authorization' always;
-            add_header 'Access-Control-Max-Age'       86400 always;
-            return 204;
-        }
+		location ~ ^/api/relay/?$ {
+				# Preflight: answer directly
+				if ($request_method = OPTIONS) {
+						add_header 'Access-Control-Allow-Origin'  ${CORS_ALLOWED_ORIGINS} always;
+						add_header 'Access-Control-Allow-Methods' 'POST, OPTIONS' always;
+						add_header 'Access-Control-Allow-Headers' 'Content-Type, Accept, Authorization' always;
+						add_header 'Access-Control-Max-Age'       86400 always;
+						return 204;
+				}
 
-        # Gate with backend auth; 2xx allows, 401/403 denies, others -> 500
-        auth_request /_auth;
+				# Gate with backend auth; 2xx allows, 401/403 denies, others -> 500
+				auth_request /_auth;
 
-        proxy_http_version 1.1;
-        proxy_request_buffering off;
-        proxy_buffering        off;
-        proxy_redirect         off;
+				proxy_http_version 1.1;
+				proxy_request_buffering off;
+				proxy_buffering        off;
+				proxy_redirect         off;
 
-        proxy_ssl_server_name on;
-        proxy_ssl_verify off;
+				proxy_ssl_server_name on;
+				proxy_ssl_verify off;
 
-        # CORS on all outcomes
-        add_header 'Access-Control-Allow-Origin' ${CORS_ALLOWED_ORIGINS} always;
+				# CORS on all outcomes
+				add_header 'Access-Control-Allow-Origin' ${CORS_ALLOWED_ORIGINS} always;
 
-        # Regex location: rewrite path first, then proxy_pass without URI
-        rewrite ^ /gateway break;
-        proxy_pass http://ohttp_gateway;
-    }
+				# Regex location: rewrite path first, then proxy_pass without URI
+				rewrite ^ /gateway break;
+				proxy_pass http://ohttp_gateway;
+		}
 }

--- a/ohttp-relay/default.conf.tpl
+++ b/ohttp-relay/default.conf.tpl
@@ -1,3 +1,18 @@
+# Resolve Docker service names at runtime via Docker's embedded DNS
+resolver 127.0.0.11 ipv6=off valid=10s;
+
+upstream wallet_backend {
+    server wallet-backend-server:8002 resolve;
+    keepalive 16;
+		zone wallet_backend 64k; # runtime DNS resolution must be in shared mem
+}
+
+upstream ohttp_gateway {
+    server gateway:4567 resolve;
+    keepalive 16;
+		zone ohttp_gateway 64k; # runtime DNS resolution must be in shared mem
+}
+
 server {
     listen 80;
 
@@ -6,15 +21,33 @@ server {
         return 200 '{"ok":true,"service":"relay","impl":"nginx"}';
     }
 
-    # merged /api/relay and /api/relay/
+    # Internal auth subrequest — checks Authorization against the backend
+    location = /_auth {
+        internal;
+        proxy_pass http://wallet_backend/helper/auth-check;
+        proxy_pass_request_body off;
+        proxy_set_header Content-Length "";
+
+        proxy_set_header Authorization $http_authorization;
+        proxy_set_header Cookie $http_cookie;
+        proxy_set_header X-Original-URI $request_uri;
+        proxy_set_header X-Real-IP        $remote_addr;
+        proxy_set_header X-Forwarded-For  $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     location ~ ^/api/relay/?$ {
+        # Preflight: answer directly
         if ($request_method = OPTIONS) {
             add_header 'Access-Control-Allow-Origin'  ${CORS_ALLOWED_ORIGINS} always;
             add_header 'Access-Control-Allow-Methods' 'POST, OPTIONS' always;
-            add_header 'Access-Control-Allow-Headers' 'Content-Type, Accept' always;
+            add_header 'Access-Control-Allow-Headers' 'Content-Type, Accept, Authorization' always;
             add_header 'Access-Control-Max-Age'       86400 always;
             return 204;
         }
+
+        # Gate with backend auth; 2xx allows, 401/403 denies, others -> 500
+        auth_request /_auth;
 
         proxy_http_version 1.1;
         proxy_request_buffering off;
@@ -24,15 +57,11 @@ server {
         proxy_ssl_server_name on;
         proxy_ssl_verify off;
 
-        proxy_set_header Host              $host;
-        proxy_set_header X-Real-IP         $remote_addr;
-        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-
+        # CORS on all outcomes
         add_header 'Access-Control-Allow-Origin' ${CORS_ALLOWED_ORIGINS} always;
 
-        # Regex location can't use proxy_pass with a URI; rewrite first, then pass
+        # Regex location: rewrite path first, then proxy_pass without URI
         rewrite ^ /gateway break;
-        proxy_pass http://gateway:4567;
+        proxy_pass http://ohttp_gateway;
     }
 }

--- a/ohttp-relay/default.conf.tpl
+++ b/ohttp-relay/default.conf.tpl
@@ -1,0 +1,38 @@
+server {
+    listen 80;
+
+    location = /health {
+        default_type application/json;
+        return 200 '{"ok":true,"service":"relay","impl":"nginx"}';
+    }
+
+    # merged /api/relay and /api/relay/
+    location ~ ^/api/relay/?$ {
+        if ($request_method = OPTIONS) {
+            add_header 'Access-Control-Allow-Origin'  ${CORS_ALLOWED_ORIGINS} always;
+            add_header 'Access-Control-Allow-Methods' 'POST, OPTIONS' always;
+            add_header 'Access-Control-Allow-Headers' 'Content-Type, Accept' always;
+            add_header 'Access-Control-Max-Age'       86400 always;
+            return 204;
+        }
+
+        proxy_http_version 1.1;
+        proxy_request_buffering off;
+        proxy_buffering        off;
+        proxy_redirect         off;
+
+        proxy_ssl_server_name on;
+        proxy_ssl_verify off;
+
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        add_header 'Access-Control-Allow-Origin' ${CORS_ALLOWED_ORIGINS} always;
+
+        # Regex location can't use proxy_pass with a URI; rewrite first, then pass
+        rewrite ^ /gateway break;
+        proxy_pass http://gateway:4567;
+    }
+}

--- a/ohttp-relay/docker-entrypoint.d/10-render-nginx-conf.sh
+++ b/ohttp-relay/docker-entrypoint.d/10-render-nginx-conf.sh
@@ -6,8 +6,8 @@ set -eu
 
 # Only substitute the vars we intend to change, leave $host etc. intact
 envsubst '${CORS_ALLOWED_ORIGINS}' \
-  < /etc/nginx/conf.d/default.conf.tpl \
-  > /etc/nginx/conf.d/default.conf
+	< /etc/nginx/conf.d/default.conf.tpl \
+	> /etc/nginx/conf.d/default.conf
 
 # Optional: remove template to avoid confusion
 rm -f /etc/nginx/conf.d/default.conf.tpl

--- a/ohttp-relay/docker-entrypoint.d/10-render-nginx-conf.sh
+++ b/ohttp-relay/docker-entrypoint.d/10-render-nginx-conf.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+# Default if not provided by the environment
+: "${CORS_ALLOWED_ORIGINS:=*}"
+
+# Only substitute the vars we intend to change, leave $host etc. intact
+envsubst '${CORS_ALLOWED_ORIGINS}' \
+  < /etc/nginx/conf.d/default.conf.tpl \
+  > /etc/nginx/conf.d/default.conf
+
+# Optional: remove template to avoid confusion
+rm -f /etc/nginx/conf.d/default.conf.tpl
+
+# Validate config early; container will exit if invalid
+nginx -t

--- a/ohttp-relay/docker-entrypoint.d/10-render-nginx-conf.sh
+++ b/ohttp-relay/docker-entrypoint.d/10-render-nginx-conf.sh
@@ -9,7 +9,6 @@ envsubst '${CORS_ALLOWED_ORIGINS}' \
 	< /etc/nginx/conf.d/default.conf.tpl \
 	> /etc/nginx/conf.d/default.conf
 
-# Optional: remove template to avoid confusion
 rm -f /etc/nginx/conf.d/default.conf.tpl
 
 # Validate config early; container will exit if invalid

--- a/ohttp-relay/nginx.conf
+++ b/ohttp-relay/nginx.conf
@@ -4,17 +4,17 @@ worker_processes  auto;
 events { worker_connections 1024; }
 
 http {
-  include       /etc/nginx/mime.types;
-  default_type  application/octet-stream;
+	include       /etc/nginx/mime.types;
+	default_type  application/octet-stream;
 
-  sendfile        on;
-  tcp_nopush      on;
-  tcp_nodelay     on;
-  keepalive_timeout  65;
-  server_tokens off;
+	sendfile        on;
+	tcp_nopush      on;
+	tcp_nodelay     on;
+	keepalive_timeout  65;
+	server_tokens off;
 
-  access_log  /var/log/nginx/access.log;
-  error_log   /var/log/nginx/error.log warn;
+	access_log  /var/log/nginx/access.log;
+	error_log   /var/log/nginx/error.log warn;
 
-  include /etc/nginx/conf.d/*.conf;
+	include /etc/nginx/conf.d/*.conf;
 }

--- a/ohttp-relay/nginx.conf
+++ b/ohttp-relay/nginx.conf
@@ -1,0 +1,20 @@
+user  nginx;
+worker_processes  auto;
+
+events { worker_connections 1024; }
+
+http {
+  include       /etc/nginx/mime.types;
+  default_type  application/octet-stream;
+
+  sendfile        on;
+  tcp_nopush      on;
+  tcp_nodelay     on;
+  keepalive_timeout  65;
+  server_tokens off;
+
+  access_log  /var/log/nginx/access.log;
+  error_log   /var/log/nginx/error.log warn;
+
+  include /etc/nginx/conf.d/*.conf;
+}

--- a/ohttp-relay/nginx.conf.template
+++ b/ohttp-relay/nginx.conf.template
@@ -17,13 +17,13 @@ server {
 
 		proxy_http_version 1.1;
 		proxy_request_buffering off;
-		proxy_buffering        off;
-		proxy_redirect         off;
+		proxy_buffering         off;
+		proxy_redirect          off;
 
-		proxy_ssl_server_name on;
-		proxy_ssl_verify off;
+		proxy_ssl_server_name   on;
+		proxy_ssl_verify        off;
 
-		proxy_set_header Host              $host;
+		proxy_set_header Host   $host;
 
 		add_header 'Access-Control-Allow-Origin' $CORS_ALLOWED_ORIGINS always;
 

--- a/ohttp-relay/nginx.conf.template
+++ b/ohttp-relay/nginx.conf.template
@@ -24,9 +24,6 @@ server {
 		proxy_ssl_verify off;
 
 		proxy_set_header Host              $host;
-		proxy_set_header X-Real-IP         $remote_addr;
-		proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
-		proxy_set_header X-Forwarded-Proto $scheme;
 
 		add_header 'Access-Control-Allow-Origin' $CORS_ALLOWED_ORIGINS always;
 

--- a/ohttp-relay/nginx.conf.template
+++ b/ohttp-relay/nginx.conf.template
@@ -6,7 +6,7 @@ server {
 		return 200 '{"ok":true,"service":"relay","impl":"nginx"}';
 	}
 
-	location = /api/relay {
+	location ~ ^/api/relay/?$ {
 		if ($request_method = OPTIONS) {
 			add_header 'Access-Control-Allow-Origin'  $CORS_ALLOWED_ORIGINS always;
 			add_header 'Access-Control-Allow-Methods' 'POST, OPTIONS' always;
@@ -15,14 +15,13 @@ server {
 			return 204;
 		}
 
-		proxy_pass http://gateway:4567/gateway;
 		proxy_http_version 1.1;
 		proxy_request_buffering off;
 		proxy_buffering        off;
 		proxy_redirect         off;
 
 		proxy_ssl_server_name on;
-		proxy_ssl_verify off; # maybe add CA in trusted later?
+		proxy_ssl_verify off;
 
 		proxy_set_header Host              $host;
 		proxy_set_header X-Real-IP         $remote_addr;
@@ -30,23 +29,8 @@ server {
 		proxy_set_header X-Forwarded-Proto $scheme;
 
 		add_header 'Access-Control-Allow-Origin' $CORS_ALLOWED_ORIGINS always;
-	}
 
-	location = /api/relay/ {
-		proxy_pass http://gateway:4567/gateway;
-		proxy_http_version 1.1;
-		proxy_request_buffering off;
-		proxy_buffering        off;
-		proxy_redirect         off;
-
-		proxy_ssl_server_name on;
-		proxy_ssl_verify off; # maybe add CA in trusted later?
-
-		proxy_set_header Host              $host;
-		proxy_set_header X-Real-IP         $remote_addr;
-		proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
-		proxy_set_header X-Forwarded-Proto $scheme;
-
-		add_header 'Access-Control-Allow-Origin' $CORS_ALLOWED_ORIGINS always;
+		rewrite ^ /gateway break;
+		proxy_pass http://gateway:4567;
 	}
 }


### PR DESCRIPTION
- Merged /api/relay locations regardless of trailing /
- Added env var replaces at entrypoint script
- Requests to /api/relay will be checked against the backend for valid auth
- Removed unnecessary and possibly identifying headers from the proxy request

Requires: https://github.com/gunet/funke-s3a-wallet-frontend/pull/17